### PR TITLE
Support for KFP build task to update workflow definition

### DIFF
--- a/application/src/main/java/it/smartcommunitylabdhub/core/services/WorkflowServiceImpl.java
+++ b/application/src/main/java/it/smartcommunitylabdhub/core/services/WorkflowServiceImpl.java
@@ -378,6 +378,23 @@ public class WorkflowServiceImpl implements SearchableWorkflowService, Indexable
         }
     }
 
+
+    @Override
+    public Workflow updateWorkflow(@NotNull String id, @NotNull Workflow workflowDTO, boolean force)
+        throws NoSuchEntityException {
+        log.debug("force update workflow with id {}", String.valueOf(id));
+        try {
+            //force update
+            //no validation
+            return entityService.update(id, workflowDTO);
+        } catch (NoSuchEntityException e) {
+            throw new NoSuchEntityException(EntityName.WORKFLOW.toString());
+        } catch (StoreException e) {
+            log.error("store error: {}", e.getMessage());
+            throw new SystemException(e.getMessage());
+        }
+    }
+
     @Override
     public void deleteWorkflow(@NotNull String id, @Nullable Boolean cascade) {
         log.debug("delete workflow with id {}", String.valueOf(id));

--- a/modules/commons/src/main/java/it/smartcommunitylabdhub/commons/services/entities/WorkflowService.java
+++ b/modules/commons/src/main/java/it/smartcommunitylabdhub/commons/services/entities/WorkflowService.java
@@ -135,6 +135,16 @@ public interface WorkflowService {
     Workflow updateWorkflow(@NotNull String id, @NotNull Workflow workflowDTO)
         throws NoSuchEntityException, BindException, IllegalArgumentException, SystemException;
 
+            /**
+     * Update a specific workflow version
+     * @param id
+     * @param workflowDTO
+     * @param force
+     * @return
+     * @throws NoSuchEntityException
+     */
+    Workflow updateWorkflow(@NotNull String id, @NotNull Workflow workflowDTO, boolean force)
+    throws NoSuchEntityException, SystemException;
     /**
      * Delete a specific workflow (version) via unique ID
      * @param id

--- a/modules/runtime-kfp/src/main/java/it/smartcommunitylabdhub/runtime/kfp/KFPRuntime.java
+++ b/modules/runtime-kfp/src/main/java/it/smartcommunitylabdhub/runtime/kfp/KFPRuntime.java
@@ -2,16 +2,22 @@ package it.smartcommunitylabdhub.runtime.kfp;
 
 import it.smartcommunitylabdhub.commons.accessors.spec.RunSpecAccessor;
 import it.smartcommunitylabdhub.commons.annotations.infrastructure.RuntimeComponent;
+import it.smartcommunitylabdhub.commons.infrastructure.RunRunnable;
 import it.smartcommunitylabdhub.commons.models.base.Executable;
 import it.smartcommunitylabdhub.commons.models.entities.run.Run;
 import it.smartcommunitylabdhub.commons.models.entities.task.Task;
 import it.smartcommunitylabdhub.commons.models.entities.task.TaskBaseSpec;
+import it.smartcommunitylabdhub.commons.models.entities.workflow.Workflow;
 import it.smartcommunitylabdhub.commons.models.utils.RunUtils;
 import it.smartcommunitylabdhub.commons.services.entities.SecretService;
+import it.smartcommunitylabdhub.commons.services.entities.WorkflowService;
 import it.smartcommunitylabdhub.framework.k8s.base.K8sBaseRuntime;
+import it.smartcommunitylabdhub.framework.k8s.runnables.K8sJobRunnable;
 import it.smartcommunitylabdhub.framework.k8s.runnables.K8sRunnable;
+import it.smartcommunitylabdhub.runtime.kfp.runners.KFPBuildRunner;
 import it.smartcommunitylabdhub.runtime.kfp.runners.KFPPipelineRunner;
 import it.smartcommunitylabdhub.runtime.kfp.specs.KFPPipelineTaskSpec;
+import it.smartcommunitylabdhub.runtime.kfp.specs.KFPBuildTaskSpec;
 import it.smartcommunitylabdhub.runtime.kfp.specs.KFPRunSpec;
 import it.smartcommunitylabdhub.runtime.kfp.specs.KFPRunStatus;
 import it.smartcommunitylabdhub.runtime.kfp.specs.KFPWorkflowSpec;
@@ -31,6 +37,9 @@ public class KFPRuntime extends K8sBaseRuntime<KFPWorkflowSpec, KFPRunSpec, KFPR
 
     @Autowired
     SecretService secretService;
+
+    @Autowired
+    private WorkflowService workflowService;
 
     @Value("${runtime.kfp.image}")
     private String image;
@@ -57,6 +66,9 @@ public class KFPRuntime extends K8sBaseRuntime<KFPWorkflowSpec, KFPRunSpec, KFPR
             switch (kind) {
                 case KFPPipelineTaskSpec.KIND -> {
                     yield new KFPPipelineTaskSpec(task.getSpec());
+                }
+                case KFPBuildTaskSpec.KIND -> {
+                    yield new KFPBuildTaskSpec(task.getSpec());
                 }
                 default -> throw new IllegalArgumentException(
                     "Kind not recognized. Cannot retrieve the right builder or specialize Spec for Run and Task."
@@ -93,10 +105,38 @@ public class KFPRuntime extends K8sBaseRuntime<KFPWorkflowSpec, KFPRunSpec, KFPR
         return switch (runAccessor.getTask()) {
             case KFPPipelineTaskSpec.KIND -> new KFPPipelineRunner(
                 image,
-                secretService.groupSecrets(run.getProject(), runKfpSpec.getTaskSpec().getSecrets())
+                secretService.groupSecrets(run.getProject(), runKfpSpec.getTaskPipelineSpec().getSecrets())
+            )
+                .produce(run);
+            case KFPBuildTaskSpec.KIND -> new KFPBuildRunner(
+                image,
+                secretService.groupSecrets(run.getProject(), runKfpSpec.getTaskBuildSpec().getSecrets())
             )
                 .produce(run);
             default -> throw new IllegalArgumentException("Kind not recognized. Cannot retrieve the right Runner");
         };
+    }
+
+    @Override
+    public KFPRunStatus onComplete(Run run, RunRunnable runnable) {
+        KFPRunSpec kfpRunSpec = new KFPRunSpec(run.getSpec());
+        RunSpecAccessor runAccessor = RunUtils.parseTask(kfpRunSpec.getTask());
+
+        if(KFPBuildTaskSpec.KIND.equals(runAccessor.getTask())) {
+            if (((K8sJobRunnable) runnable).getResults() != null) {
+                String workflow = (String)((K8sJobRunnable) runnable).getResults().get("workflow");
+                String wId = runAccessor.getVersion();
+                Workflow wf = workflowService.getWorkflow(wId);
+    
+                log.debug("update workflow {} spec to use built workflow", wId);
+    
+                KFPWorkflowSpec wfSpec = new KFPWorkflowSpec(wf.getSpec());
+                wfSpec.setWorkflow(workflow);
+                wf.setSpec(wfSpec.toMap());
+                workflowService.updateWorkflow(wId, wf, true);    
+            }
+        }
+
+        return null;
     }
 }

--- a/modules/runtime-kfp/src/main/java/it/smartcommunitylabdhub/runtime/kfp/specs/KFPBuildTaskSpec.java
+++ b/modules/runtime-kfp/src/main/java/it/smartcommunitylabdhub/runtime/kfp/specs/KFPBuildTaskSpec.java
@@ -1,0 +1,29 @@
+package it.smartcommunitylabdhub.runtime.kfp.specs;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import it.smartcommunitylabdhub.commons.annotations.common.SpecType;
+import it.smartcommunitylabdhub.commons.models.enums.EntityName;
+import it.smartcommunitylabdhub.framework.k8s.base.K8sTaskBaseSpec;
+import it.smartcommunitylabdhub.runtime.kfp.KFPRuntime;
+import java.io.Serializable;
+import java.util.Map;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@SpecType(runtime = KFPRuntime.RUNTIME, kind = KFPBuildTaskSpec.KIND, entity = EntityName.TASK)
+public class KFPBuildTaskSpec extends K8sTaskBaseSpec {
+
+    public static final String KIND = "kfp+build";
+
+    public KFPBuildTaskSpec(Map<String, Serializable> data) {
+        configure(data);
+    }
+
+}

--- a/modules/runtime-kfp/src/main/java/it/smartcommunitylabdhub/runtime/kfp/specs/KFPPipelineTaskSpec.java
+++ b/modules/runtime-kfp/src/main/java/it/smartcommunitylabdhub/runtime/kfp/specs/KFPPipelineTaskSpec.java
@@ -1,6 +1,5 @@
 package it.smartcommunitylabdhub.runtime.kfp.specs;
 
-import io.swagger.v3.oas.annotations.media.Schema;
 import it.smartcommunitylabdhub.commons.Keys;
 import it.smartcommunitylabdhub.commons.annotations.common.SpecType;
 import it.smartcommunitylabdhub.commons.models.enums.EntityName;
@@ -26,9 +25,6 @@ public class KFPPipelineTaskSpec extends K8sTaskBaseSpec {
     @Pattern(regexp = Keys.CRONTAB_PATTERN)
     private String schedule;
 
-    @Schema(format = "yaml")
-    private String workflow;
-
     public KFPPipelineTaskSpec(Map<String, Serializable> data) {
         configure(data);
     }
@@ -39,6 +35,5 @@ public class KFPPipelineTaskSpec extends K8sTaskBaseSpec {
 
         KFPPipelineTaskSpec spec = mapper.convertValue(data, KFPPipelineTaskSpec.class);
         this.schedule = spec.getSchedule();
-        this.workflow = spec.getWorkflow();
     }
 }

--- a/modules/runtime-kfp/src/main/java/it/smartcommunitylabdhub/runtime/kfp/specs/KFPRunSpec.java
+++ b/modules/runtime-kfp/src/main/java/it/smartcommunitylabdhub/runtime/kfp/specs/KFPRunSpec.java
@@ -34,7 +34,10 @@ public class KFPRunSpec extends RunBaseSpec {
 
     // @JsonProperty("pipeline_spec")
     @JsonUnwrapped
-    private KFPPipelineTaskSpec taskSpec;
+    private KFPPipelineTaskSpec taskPipelineSpec;
+
+    @JsonUnwrapped
+    private KFPBuildTaskSpec taskBuildSpec;
 
     public KFPRunSpec(Map<String, Serializable> data) {
         configure(data);
@@ -49,7 +52,8 @@ public class KFPRunSpec extends RunBaseSpec {
         this.outputs = spec.getOutputs();
         this.parameters = spec.getParameters();
 
-        this.taskSpec = spec.getTaskSpec();
+        this.taskPipelineSpec = spec.getTaskPipelineSpec();
+        this.taskBuildSpec = spec.getTaskBuildSpec();
         this.workflowSpec = spec.getWorkflowSpec();
     }
 
@@ -57,7 +61,12 @@ public class KFPRunSpec extends RunBaseSpec {
         this.workflowSpec = workflowSpec;
     }
 
-    public void setTaskSpec(KFPPipelineTaskSpec taskSpec) {
-        this.taskSpec = taskSpec;
+    public void setTaskPipelineSpec(KFPPipelineTaskSpec taskPipelineSpec) {
+        this.taskPipelineSpec = taskPipelineSpec;
     }
+
+    public void setTaskBuildSpec(KFPBuildTaskSpec taskBuildSpec) {
+        this.taskBuildSpec = taskBuildSpec;
+    }
+
 }

--- a/modules/runtime-kfp/src/main/java/it/smartcommunitylabdhub/runtime/kfp/specs/KFPWorkflowSpec.java
+++ b/modules/runtime-kfp/src/main/java/it/smartcommunitylabdhub/runtime/kfp/specs/KFPWorkflowSpec.java
@@ -2,6 +2,7 @@ package it.smartcommunitylabdhub.runtime.kfp.specs;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import it.smartcommunitylabdhub.commons.annotations.common.SpecType;
+import it.smartcommunitylabdhub.commons.jackson.annotations.JsonSchemaIgnore;
 import it.smartcommunitylabdhub.commons.models.entities.workflow.WorkflowBaseSpec;
 import it.smartcommunitylabdhub.commons.models.enums.EntityName;
 import it.smartcommunitylabdhub.commons.models.objects.SourceCode;
@@ -32,6 +33,9 @@ public class KFPWorkflowSpec extends WorkflowBaseSpec {
     @Schema(title = "fields.sourceCode.handler.title", description = "fields.sourceCode.handler.description")
     private String handler;
 
+    @JsonSchemaIgnore
+    private String workflow;
+    
     public KFPWorkflowSpec(Map<String, Serializable> data) {
         configure(data);
     }
@@ -46,6 +50,7 @@ public class KFPWorkflowSpec extends WorkflowBaseSpec {
         this.image = spec.getImage();
         this.tag = spec.getTag();
         this.handler = spec.getHandler();
+        this.workflow = spec.getWorkflow();
     }
 
     public enum KFPSourceCodeLanguages {


### PR DESCRIPTION
Split KFP tasks in 'build' and 'pipeline'. The former is used to compile the pipeline code definition into the workflow DAG using KFP compiler. The latter triggers the execution of the pipeline using the KFP API. 